### PR TITLE
set gpio direction as output

### DIFF
--- a/drivers/media/i2c/tevi_ap1302/main.c
+++ b/drivers/media/i2c/tevi_ap1302/main.c
@@ -1433,6 +1433,7 @@ static struct camera_common_pdata *sensor_parse_dt(
 		goto error;
 	}
 	board_priv_pdata->reset_gpio = (unsigned int)gpio;
+	gpio_direction_output(board_priv_pdata->reset_gpio, 1);
 
 	err = of_property_read_string(np, "mclk", &board_priv_pdata->mclk_name);
 	if (err)


### PR DESCRIPTION
reset_gpio was not being set as an output. When the pin was not an output as default this would cause the reset pin to stay floating instead of being driven high and low.